### PR TITLE
Add Dockerfile for image, and a docker-compose setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+vendor
+.env
+.env.*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,46 @@
+# ---- Docker Image Configuration ----
+
+# ---- Dependencies ----
+FROM composer:1.7 AS dependencies
+# A wildcard is used to ensure both composer.json AND composer.lock are copied
+COPY composer.* /app/
+# install app dependencies
+RUN composer install --no-dev --no-suggest --optimize-autoloader
+
+# --- Release with Alpine ----
+FROM php:7-fpm-alpine AS release
+
+LABEL maintainer="https://github.com/alashow/datmusic-api"
+LABEL description="Alternative for VK Audio API"
+
+# UID and GID for datmusic user
+ARG UID=991
+ARG GID=991
+
+ARG WORK_DIR_IN_IMAGE=/usr/src/datmusic
+
+# Create app directory
+WORKDIR ${WORK_DIR_IN_IMAGE}
+
+# Copy dependencies from composer
+COPY --from=dependencies /app/vendor ./vendor
+
+# Copy app files
+COPY . ./
+
+# When running use datmusic user for avoid running as root inside the container
+# Php will run as datmusic
+RUN addgroup -g ${GID} datmusic \
+      && adduser -h ${WORK_DIR_IN_IMAGE} -s /bin/sh -D -G datmusic -u ${UID} datmusic \
+      && mkdir -p ${WORK_DIR_IN_IMAGE}/storage/app/public/mp3 \
+      && mkdir -p ${WORK_DIR_IN_IMAGE}/storage/app/public/links \
+      && mkdir -p ${WORK_DIR_IN_IMAGE}/storage/app/cookies \
+      && chown -R datmusic:datmusic ${WORK_DIR_IN_IMAGE}/storage
+
+# Use the default production configuration
+RUN mv $PHP_INI_DIR/php.ini-production $PHP_INI_DIR/php.ini
+
+USER datmusic
+
+VOLUME ${WORK_DIR_IN_IMAGE}/storage
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '3.2'
+services:
+  php:
+    build: .
+    image: alashow/datmusic-api
+    restart: always
+    env_file: .env
+    volumes:
+      - datmusic-storage:/usr/src/datmusic/storage
+  web:
+    image: nginx:latest
+    ports:
+      - "3002:80"
+    volumes:
+      # Using the same path here to correctly resolve absolute symlinks
+      # TODO create symlink in links with relative path in storage
+      - datmusic-storage:/usr/src/datmusic/storage:ro
+      - ./docker-config/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+volumes:
+  datmusic-storage:
+    driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
     image: nginx:latest
     ports:
       - "3002:80"
+    depends_on:
+      - php
     volumes:
       # Using the same path here to correctly resolve absolute symlinks
       # TODO create symlink in links with relative path in storage

--- a/docker-config/nginx.conf
+++ b/docker-config/nginx.conf
@@ -1,0 +1,30 @@
+server {
+    listen 80;
+    index index.php index.html;
+    server_name localhost;
+    error_log  /var/log/nginx/error.log;
+    access_log /var/log/nginx/access.log;
+    # Using the same path that in php container for resolving absolute symlinks
+    root /usr/src/datmusic/storage/app/public;
+
+    location / {
+      try_files $uri $uri/ /index.php?$query_string;
+    }
+
+    location ~ /links/.+\.mp3$ {
+      types {
+        application/octet-stream;
+      }
+    }
+
+    location ~ \.php$ {
+        try_files $uri /index.php =404;
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_pass php:9000;
+        fastcgi_index index.php;
+        include fastcgi_params;
+        # The script path is the path in the php fpm container
+        fastcgi_param SCRIPT_FILENAME /usr/src/datmusic/public/$fastcgi_script_name;
+        fastcgi_param PATH_INFO $fastcgi_path_info;
+    }
+}

--- a/docker-config/nginx.conf
+++ b/docker-config/nginx.conf
@@ -1,30 +1,27 @@
 server {
     listen 80;
-    index index.php index.html;
     server_name localhost;
     error_log  /var/log/nginx/error.log;
     access_log /var/log/nginx/access.log;
     # Using the same path that in php container for resolving absolute symlinks
     root /usr/src/datmusic/storage/app/public;
 
-    location / {
-      try_files $uri $uri/ /index.php?$query_string;
-    }
-
-    location ~ /links/.+\.mp3$ {
+    location /links {
+      try_files $uri =404;
       types {
         application/octet-stream;
       }
     }
 
-    location ~ \.php$ {
-        try_files $uri /index.php =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+    location /mp3 {
+      try_files $uri =404;
+    }
+
+    location / {
         fastcgi_pass php:9000;
-        fastcgi_index index.php;
         include fastcgi_params;
         # The script path is the path in the php fpm container
-        fastcgi_param SCRIPT_FILENAME /usr/src/datmusic/public/$fastcgi_script_name;
+        fastcgi_param SCRIPT_FILENAME /usr/src/datmusic/public/index.php;
         fastcgi_param PATH_INFO $fastcgi_path_info;
     }
 }

--- a/readme.md
+++ b/readme.md
@@ -91,6 +91,21 @@ Please browse code or open an issue to understand more.
 
 Open an issue or contact me at me@alashov.com for help with deployment.
 
+# Deployment with Docker
+
+1. Run `git clone https://github.com/alashow/datmusic-api.git`
+1. Run `cd datmusic-api`
+1. Edit `docker-compose.yml` to tweak exposed port by default 3002 is
+   used. A volume is created for storage persistence.
+1. Copy the config `cp .env.example .env`
+1. Edit the config in `.env`
+1. Run `docker-compose build`
+1. Run `docker-compose up`
+
+You can used docker image alone, you will need a web server for frontend
+like nginx or apache. The nginx docker config is in
+`docker-config/nginx.conf`.
+
 ## License
 
     Copyright (C) 2017  Alashov Berkeli


### PR DESCRIPTION
## Dockerify the app for deployment
* The base image is the official php-fpm-alpine
* I'm not an expert in Docker stuff
* The php container run as datmusic user for better security. The code is readonly owned by root.
* Only storage is writable.
* I provide a docker-compose with a minimal nginx frontend setup.

## Some issue that can be annoying
* There is an issue with symlinks in `app/links` storage folder created in absolute way. This prevent using an another path in the frontend webserver that the one in the php container. This issue need some php code change. I can do a proposal for that.

## Other notes
* I may add Redis in docker-compose configuration.
* I may need to mount only public storage in the nginx container, but I cannot find a simple way of doing this (maybe split storage public vs other stuff) not critical
* Logs are not configured properly ! We need all logs to be redirected to stdout or stderr for the php container I think. ( Some logs are created in storage/logs )